### PR TITLE
Cancel Fetch on Unmount (and Other Updates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+yarn.lock
+node_modules

--- a/SvgImage.js
+++ b/SvgImage.js
@@ -2,15 +2,12 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { View, WebView, StyleSheet } from 'react-native';
+import { View, WebView } from 'react-native';
 import Promise from 'bluebird';
 Promise.config({ cancellation: true }); // Need to explicitly enable this feature
 
-// Calculate this once
-const styleType = PropTypes.oneOfType([
-  PropTypes.instanceOf(StyleSheet.create({display:"none"}).constructor).isRequired,
-  PropTypes.object.isRequired,
-]);
+// TODO Make this something more precise oneOf(object,_?_), where _?_ is the type returned by `StyleSheet.create`.
+const styleType = PropTypes.object.isRequired;
 
 const firstHtml =
   '<html><head><style>html, body { margin:0; padding:0; overflow:hidden; background-color: transparent; } svg { position:fixed; top:0; left:0; height:100%; width:100% }</style></head><body>';

--- a/SvgImage.js
+++ b/SvgImage.js
@@ -6,6 +6,12 @@ import { View, WebView, StyleSheet } from 'react-native';
 import Promise from 'bluebird';
 Promise.config({ cancellation: true }); // Need to explicitly enable this feature
 
+// Calculate this once
+const styleType = PropTypes.oneOfType([
+  PropTypes.instanceOf(StyleSheet.create({display:"none"}).constructor).isRequired,
+  PropTypes.object.isRequired,
+]);
+
 const firstHtml =
   '<html><head><style>html, body { margin:0; padding:0; overflow:hidden; background-color: transparent; } svg { position:fixed; top:0; left:0; height:100%; width:100% }</style></head><body>';
 const lastHtml = '</body></html>';
@@ -16,14 +22,8 @@ class SvgImage extends Component {
     source: PropTypes.shape({
         uri: PropTypes.string.isRequired
       }).isRequired,
-    containerStyle: PropTypes.oneOfType([
-        PropTypes.instanceOf(StyleSheet).isRequired,
-        PropTypes.object.isRequired,
-      ]),
-    style: PropTypes.oneOfType([
-        PropTypes.instanceOf(StyleSheet).isRequired,
-        PropTypes.object.isRequired,
-    ]),
+    containerStyle: styleType,
+    style: styleType,
   }
 
   state = {

--- a/SvgImage.js
+++ b/SvgImage.js
@@ -61,7 +61,6 @@ class SvgImage extends Component {
           Promise.resolve(fetch(uri))
             .call("text")
             .then(text => this.setState({ svgContent: text }))
-            .timeout(1000 * 60, `SVG URI fetch timed out: ${uri}`)
             .catch(e => console.error(`Error fetching SVG URI: ${e.message||e}`, {uri, e}))
             .return((previousFetch && previousFetch.isPending()) ? previousFetch : null) // Ensure we resolve/cancel previous fetch
         }))

--- a/SvgImage.js
+++ b/SvgImage.js
@@ -7,7 +7,7 @@ import Promise from 'bluebird';
 Promise.config({ cancellation: true }); // Need to explicitly enable this feature
 
 // TODO Make this something more precise oneOf(object,_?_), where _?_ is the type returned by `StyleSheet.create`.
-const styleType = PropTypes.object.isRequired;
+const styleType = PropTypes.object;
 
 const firstHtml =
   '<html><head><style>html, body { margin:0; padding:0; overflow:hidden; background-color: transparent; } svg { position:fixed; top:0; left:0; height:100%; width:100% }</style></head><body>';

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "image"
   ],
   "dependencies": {
-    "debug": "^3.1.0"
+    "bluebird": "^3.5.1",
+    "debug": "^3.1.0",
+    "prop-types": "^15.6.2"
   },
   "devDependencies": {
     "supports-color": "^5.4.0"

--- a/package.json
+++ b/package.json
@@ -16,5 +16,11 @@
     "react-native",
     "svg",
     "image"
-  ]
+  ],
+  "dependencies": {
+    "debug": "^3.1.0"
+  },
+  "devDependencies": {
+    "supports-color": "^5.4.0"
+  }
 }


### PR DESCRIPTION
This PR does the following things:

  1. Add in `PropTypes` so that we give our users feedback on whether or not they are passing the correct parameters. (They can remove them in production using [`babel-plugin-transform-react-remove-prop-types`](https://devarchy.com/react/library/babel-plugin-transform-react-remove-prop-types).)
  2. Capture the promise that is performing the `fetch`, so that we can cancel it on unmount. This saves a memory leak and a warning message whenever someone navigates away before the `fetch` resolves.
  3. Switch  to [Bluebird](http://bluebirdjs.com/docs/features.html) so that we have the `promise.cancel()` functionality required in #3.
  4. Chain the promises, so multiple rapid changes would still all be cancelled on unmount. 
  5. Move off of [deprecated React.Component methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) to their contemporary alternatives.