### PR TITLE
Made fix for webview to support rn using expo

### DIFF
--- a/SvgImage.js
+++ b/SvgImage.js
@@ -1,8 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
-import { View, Platform } from 'react-native';
-import { WebView } from 'react-native-webview';
+import { View, Platform, WebView } from 'react-native';
 
 const firstHtml =
   '<html><head><style>html, body { margin:0; padding:0; overflow:hidden; background-color: transparent; } svg { position:fixed; top:0; left:0; height:100%; width:100% }</style></head><body>';

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react": ">=15",
-    "react-native": ">=0.57 <0.59",
-    "react-native-webview": ">=5.2.4"
+    "react-native": ">=0.57 <0.59"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Background context:
Currently working on a RN project using expo. After digging in the code of your package, I saw that SVGImage.js was using WebView from the package. Unfortunately using this component from `react-native-webview` requires a user to eject their application and do `react-native-link`. However upon tweaking the code, I discovered that the WebView component exists in the `react-native` package, which allows you to use your `SVGImage` in expo


Made fix for webview to support rn using expo. removed react-native-webview from package json. Webview component is now included react native so no need to have extra package.
SvgImage: removed import for react-native-webview and used WebView component from react-native package