### PR TITLE
Fix for resizing SVGs which don't have viewBox

### DIFF
--- a/SvgImage.js
+++ b/SvgImage.js
@@ -4,7 +4,19 @@ import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
 
-const getHTML = (svgContent, style) => `
+const getHTML = (svgContent, style) => {
+  if (!svgContent.includes("viewBox")) {
+    // if no viewBox, add a viewBox with the same height and width as the svg
+    // (I assume that no viewBox means the <svg> tag has a height and width)
+    // Any improvements on the regex is appreciated
+
+    try{
+      height = svgContent.match(/(?:height ?= ?(?:"|'))([0-9]+\.?[0-9]*)(?=(?:"|'))/)[1];
+      width = svgContent.match(/(?:width ?= ?(?:"|'))([0-9]+\.?[0-9]*)(?=(?:"|'))/)[1];
+      svgContent = svgContent.replace(`<svg`, `<svg viewBox="0 0 ${width} ${height}"`);
+    } catch (error){}
+  }
+  return `
 <html data-key="key-${style.height}-${style.width}">
   <head>
     <style>
@@ -31,6 +43,7 @@ const getHTML = (svgContent, style) => `
   </body>
 </html>
 `;
+};
 
 class SvgImage extends Component {
   state = { fetchingUrl: null, svgContent: null };


### PR DESCRIPTION
**Potential fix for issue #3**

As I understood, the SVGs that do not have viewBox cause the image clipping problem. If we add a viewBox that is the same height and width as the SVG, it is possible to resize it with styles. (Assumption: No viewBox must mean the \<svg\> tag should be having a height and width)

Tested with:
1) API: https://restcountries.eu SVG flags
2) The SVG in the aforementioned issue.

Can you please review the fix and see if it's worth anything?