### PR TITLE
Add the ability to override css svg fill field

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,7 @@ import Image from 'react-native-remote-svg';
       <ellipse data-custom-shape="ellipse" cx="50" cy="50" rx="50" ry="50" fill="green"  stroke="#00FF00" stroke-width ="2" />
     </svg>`,
   }}
-  style={{ width: 100, height: 100 }}
+  style={{ width: 100, height: 100, fill: '#00ffff' /* override svg fill */ }}
 />;
 ```
 
@@ -74,7 +74,7 @@ You can load normal jpg/png images as well
 ```js
 <Image
   source={{ uri: 'https://example.com/my-other-pic.png' }
-  style={{ width: 100, height: 120}}
+  style={{ width: 100, height: 120, fill: '#00ffff' /* override svg fill */}}
 />
 ```
 

--- a/SvgImage.js
+++ b/SvgImage.js
@@ -23,6 +23,7 @@ const getHTML = (svgContent, style) => `
         height: 100%;
         width: 100%;
         overflow: hidden;
+        fill: ${style.fill};
       }
     </style>
   </head>


### PR DESCRIPTION
#### Description
Adding the ability to customize `fill` style property of the svg image that's embedded in the `WebView` wrapper

#### Use case
I wanted the ability to customize `fill` property of the svg file that's embedded through this component so I can modify update `svg` fill value on demand rather than modifying the content of the svg file.