### PR TITLE
fix: change regexp to manage file ending by .svg

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import SvgImage from './SvgImage';
 
 const MyImage = props => {
   const source = resolveAssetSource(props.source);
-  if (source && (source.uri && source.uri.match('.svg'))) {
+  if (source && (source.uri && source.uri.match('^[^?]+\\.svg(\\?.*)?$'))) {
     const style = props.style || {};
     if (source.__packager_asset && typeof style !== 'number') {
       if (!style.width) {


### PR DESCRIPTION
We should manage files ending with `.svg`

Which means by example :
- http://example.com/my-image.svg
- http://example.com/my-image.svg?my-param=value

But not
- http://example.com/my-image.svg.converted-to.png
- http://example.com/my-image.png?from.svg
- http://example.com/my-image.png?converted-from.svg?nocache
- http://example.com/my-image.tosvg

Test with https://regex101.com/r/TkaBn6