### PR TITLE
Pass all props to webview

### DIFF
--- a/SvgImage.js
+++ b/SvgImage.js
@@ -48,7 +48,6 @@ class SvgImage extends Component {
   doFetch = async props => {
     let uri = props.source && props.source.uri;
     if (uri) {
-      props.onLoadStart && props.onLoadStart();
       if (uri.match(/^data:image\/svg/)) {
         const index = uri.indexOf('<svg');
         this.setState({ fetchingUrl: uri, svgContent: uri.slice(index) });
@@ -61,7 +60,6 @@ class SvgImage extends Component {
           console.error('got error', err);
         }
       }
-      props.onLoadEnd && props.onLoadEnd();
     }
   };
   render() {
@@ -74,6 +72,7 @@ class SvgImage extends Component {
       return (
         <View pointerEvents="none" style={[props.style, props.containerStyle]}>
           <WebView
+            {...props}
             originWhitelist={['*']}
             scalesPageToFit={true}
             useWebKit={false}
@@ -88,7 +87,7 @@ class SvgImage extends Component {
             scrollEnabled={false}
             showsHorizontalScrollIndicator={false}
             showsVerticalScrollIndicator={false}
-            source={{ html }}
+            source={{ html, baseUrl: '' }}
           />
         </View>
       );


### PR DESCRIPTION
Pass all props to the WebView before setting the specific WebView props required by react-native-remote-svg.

The `baseUrl` added to the `source` prop fixed an issue where iOS does not fire the `onLoad...` events. This also means that the calls to `onLoadStart` and 'onLoadEnd' can be removed, as they will be delegated to the WebView.