### PR TITLE
Issue 53 migrate from deprecated uiwebview

### DIFF
--- a/SvgImage.js
+++ b/SvgImage.js
@@ -75,8 +75,7 @@ class SvgImage extends Component {
         <View pointerEvents="none" style={[props.style, props.containerStyle]}>
           <WebView
             originWhitelist={['*']}
-            scalesPageToFit={true}
-            useWebKit={false}
+            useWebKit
             style={[
               {
                 width: 200,


### PR DESCRIPTION
I removed the usage of UIWebView since it's a deprecated API and Apple has warned that they will not be accepting apps to the AppStore that use it (See https://github.com/seekshiva/react-native-remote-svg/issues/53)

When I enabled the use of WKWebView instead of UIWebView, I also had to remove the `scalesPageToFit` setting since it's not supported in WKWebView.

There's an issue with transparent backgrounds on WKWebView so the WebView displayed a white background before loading the SVG. I followed the workaround suggested here: https://github.com/react-native-community/react-native-webview/issues/318#issuecomment-470366316 to prevent the white background to show.