### PR TITLE
fixed crash on Android

### DIFF
--- a/SvgImage.js
+++ b/SvgImage.js
@@ -72,7 +72,8 @@ class SvgImage extends Component {
       const html = getHTML(svgContent, flattenedStyle);
 
       return (
-        <View pointerEvents="none" style={[props.style, props.containerStyle]}>
+        <View pointerEvents="none" style={[props.style, props.containerStyle]}
+          renderToHardwareTextureAndroid={true}>
           <WebView
             originWhitelist={['*']}
             scalesPageToFit={true}


### PR DESCRIPTION
Added `renderToHardwareTextureAndroid={true}` to prevent crashing on Android. As suggested by these docs: https://lonelycpp.github.io/react-native-youtube-iframe/navigation-crash/#set-rendertohardwaretextureandroid-issue-comment